### PR TITLE
Return null for hexlify with null inputs

### DIFF
--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -20,6 +20,10 @@ function random(length: number = 32): string {
  * @returns hex string
  */
 function hexlify(data: BytesData, prefix = false): string {
+  if (data == null) {
+    return '';
+  }
+
   let hexString = '';
 
   if (typeof data === 'string') {


### PR DESCRIPTION
This fixes a silent error when debugging queueLeaves.