### PR TITLE
Refactor transaction solutions into batches

### DIFF
--- a/src/contract/erc20/RailgunLogic.json
+++ b/src/contract/erc20/RailgunLogic.json
@@ -440,13 +440,6 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "forceNewTree",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "components": [

--- a/src/contract/erc20/events.ts
+++ b/src/contract/erc20/events.ts
@@ -6,7 +6,7 @@ import {
   EncryptedData,
   GeneratedCommitment,
   Nullifier,
-} from '../../models/transaction-types';
+} from '../../models/formatted-types';
 import { ByteLength, formatToByteLength, hexlify, nToHex } from '../../utils/bytes';
 import { ERC20WithdrawNote } from '../../note/erc20-withdraw';
 import LeptonDebug from '../../debugger';

--- a/src/contract/erc20/index.ts
+++ b/src/contract/erc20/index.ts
@@ -14,7 +14,7 @@ import {
   CommitmentPreimage,
   EncryptedData,
   SerializedTransaction,
-} from '../../models/transaction-types';
+} from '../../models/formatted-types';
 import {
   CommitmentBatchEventArgs,
   CommitmentCiphertextArgs,

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -2,7 +2,7 @@ import type { AbstractBatch, AbstractLevelDOWN } from 'abstract-leveldown';
 import encode from 'encoding-down';
 import type { LevelUp } from 'levelup';
 import levelup from 'levelup';
-import { BytesData, Ciphertext } from '../models/transaction-types';
+import { BytesData, Ciphertext } from '../models/formatted-types';
 import { bytes, encryption } from '../utils';
 
 // TODO: Remove JSON encoding and standardize everything as msgpack

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { Wallet } from './wallet';
 import { CommitmentEvent } from './contract/erc20';
 import LeptonDebug from './debugger';
 import { LeptonDebugger } from './models/types';
-import { BytesData, Commitment, Nullifier } from './models/transaction-types';
+import { BytesData, Commitment, Nullifier } from './models/formatted-types';
 
 export type AccumulatedEvents = {
   commitmentEvents: CommitmentEvent[];

--- a/src/keyderivation/bip32.ts
+++ b/src/keyderivation/bip32.ts
@@ -1,6 +1,6 @@
 import { Signature } from 'circomlibjs';
 import { bytesToHex } from 'ethereum-cryptography/utils';
-import { BytesData } from '../models/transaction-types';
+import { BytesData } from '../models/formatted-types';
 import { KeyNode } from '../models/types';
 import { hash, keysUtils } from '../utils';
 import { childKeyDerivationHardened, getPathSegments } from '../utils/bip32';

--- a/src/merkletree/index.ts
+++ b/src/merkletree/index.ts
@@ -13,7 +13,7 @@ import {
   hexToBigInt,
 } from '../utils/bytes';
 import LeptonDebug from '../debugger';
-import { Commitment, MerkleProof, Nullifier } from '../models/transaction-types';
+import { Commitment, MerkleProof, Nullifier } from '../models/formatted-types';
 
 // eslint-disable-next-line no-unused-vars
 export type RootValidator = (tree: number, root: string) => Promise<boolean>;

--- a/src/models/formatted-types.ts
+++ b/src/models/formatted-types.ts
@@ -58,7 +58,7 @@ export type SerializedTransaction = {
   nullifiers: bigint[];
   commitments: bigint[];
   boundParams: BoundParams;
-  withdrawPreimage?: CommitmentPreimage;
+  withdrawPreimage: CommitmentPreimage;
   overrideOutput: string;
 };
 

--- a/src/models/txo-types.ts
+++ b/src/models/txo-types.ts
@@ -1,0 +1,16 @@
+import { Note } from '../note/note';
+
+export type TXO = {
+  tree: number;
+  position: number;
+  txid: string;
+  spendtxid: string | false;
+  note: Note;
+};
+
+export type SpendingSolutionGroup = {
+  utxos: TXO[];
+  spendingTree: number;
+  outputs: Note[];
+  withdrawValue: bigint;
+};

--- a/src/note/erc20-deposit.ts
+++ b/src/note/erc20-deposit.ts
@@ -1,4 +1,4 @@
-import { CommitmentPreimage, EncryptedData, TokenType } from '../models/transaction-types';
+import { CommitmentPreimage, EncryptedData, TokenType } from '../models/formatted-types';
 import { encryption } from '../utils';
 import { ByteLength, hexToBigInt, nToHex } from '../utils/bytes';
 import { ciphertextToEncryptedRandomData } from '../utils/ciphertext';

--- a/src/note/erc20-withdraw.ts
+++ b/src/note/erc20-withdraw.ts
@@ -1,4 +1,4 @@
-import { CommitmentPreimage, TokenData, TokenType } from '../models/transaction-types';
+import { CommitmentPreimage, TokenData, TokenType } from '../models/formatted-types';
 import { ByteLength, formatToByteLength, hexToBigInt, nToHex } from '../utils/bytes';
 import { ZERO_ADDRESS } from '../utils/constants';
 import { poseidon } from '../utils/hash';

--- a/src/note/note.ts
+++ b/src/note/note.ts
@@ -1,6 +1,6 @@
 import { Signature } from 'circomlibjs';
 import { AddressData } from '../keyderivation/bech32-encode';
-import { BigIntish, Ciphertext, NoteSerialized, TokenType } from '../models/transaction-types';
+import { BigIntish, Ciphertext, NoteSerialized, TokenType } from '../models/formatted-types';
 import { PublicInputs } from '../prover/types';
 import { encryption, keysUtils } from '../utils';
 import { ByteLength, formatToByteLength, hexlify, hexToBigInt, nToHex } from '../utils/bytes';

--- a/src/transaction/constants.ts
+++ b/src/transaction/constants.ts
@@ -1,12 +1,5 @@
 export const DEFAULT_TOKEN_SUB_ID = BigInt(0);
 
-export const NOTE_INPUTS = {
-  small: 2,
-  large: 10,
-};
-
-export const NOTE_OUTPUTS = 3;
-
 export const WithdrawFlag = {
   NO_WITHDRAW: BigInt(0),
   WITHDRAW: BigInt(1),

--- a/src/transaction/transaction-batch.ts
+++ b/src/transaction/transaction-batch.ts
@@ -1,0 +1,233 @@
+import { Note } from '../note';
+import { bytes } from '../utils';
+import { Wallet, TXO, TreeBalance } from '../wallet';
+import { Prover } from '../prover';
+import { ByteLength, formatToByteLength } from '../utils/bytes';
+import { calculateTotalSpend, findSolutions } from './solutions';
+import { Transaction } from './transaction';
+import { SpendingSolutionGroup } from '../models/txo-types';
+import { TokenType, BigIntish, SerializedTransaction } from '../models/formatted-types';
+
+class TransactionBatch {
+  private chainID: number;
+
+  private tokenAddress: string;
+
+  private outputs: Note[] = [];
+
+  private tokenType: TokenType;
+
+  private withdrawAddress: string | undefined;
+
+  private withdrawTotal: bigint = BigInt(0);
+
+  private overrideWithdrawAddress: string | undefined;
+
+  /**
+   * Create ERC20Transaction Object
+   * @param tokenAddress - token address, unformatted
+   * @param tokenType - enum of token type
+   * @param chainID - chainID of network transaction will be built for
+   */
+  constructor(tokenAddress: string, tokenType: TokenType, chainID: number) {
+    this.tokenAddress = formatToByteLength(tokenAddress, ByteLength.UINT_256);
+    this.tokenType = tokenType;
+    this.chainID = chainID;
+  }
+
+  addOutput(output: Note) {
+    this.outputs.push(output);
+  }
+
+  resetOutputs() {
+    this.outputs = [];
+  }
+
+  setWithdraw(withdrawAddress: string, value: BigIntish, overrideWithdrawAddress?: string) {
+    if (this.withdrawAddress != null) {
+      throw new Error('You may only call .withdraw once for a given transaction batch.');
+    }
+
+    this.withdrawAddress = withdrawAddress;
+    this.withdrawTotal = BigInt(value);
+    this.overrideWithdrawAddress = overrideWithdrawAddress;
+  }
+
+  /**
+   * Generates spending solution groups for outputs
+   * @param wallet - wallet to spend from
+   */
+  async generateValidSpendingSolutionGroups(wallet: Wallet): Promise<SpendingSolutionGroup[]> {
+    const outputTotal = this.outputs.reduce((left, right) => left + right.value, BigInt(0));
+
+    // Calculate total required to be supplied by UTXOs
+    const totalRequired = outputTotal + this.withdrawTotal;
+
+    // Check if output token fields match tokenID for this transaction
+    this.outputs.forEach((output, index) => {
+      if (output.token !== this.tokenAddress)
+        throw new Error(`Token address mismatch on output ${index}`);
+    });
+
+    // Get UTXOs sorted by tree
+    const treeSortedBalances = (await wallet.balancesByTree(this.chainID))[
+      formatToByteLength(this.tokenAddress, 32, false)
+    ];
+
+    if (treeSortedBalances === undefined) {
+      const formattedTokenAddress = `0x${bytes.trim(this.tokenAddress, ByteLength.Address)}`;
+      throw new Error(`No wallet balance for token: ${formattedTokenAddress}`);
+    }
+
+    // Sum balances
+    const balance: bigint = treeSortedBalances.reduce(
+      (left, right) => left + right.balance,
+      BigInt(0),
+    );
+
+    // Check if wallet balance is enough to cover this transaction
+    if (totalRequired > balance) throw new Error('Wallet balance too low');
+
+    // If single group possible, return it.
+    const singleSpendingSolutionGroup = this.createSingleSpendingSolutionGroupIfPossible(
+      treeSortedBalances,
+      totalRequired,
+    );
+    if (singleSpendingSolutionGroup) {
+      return [singleSpendingSolutionGroup];
+    }
+
+    // Single group not possible - need a more complex model.
+    throw new Error(
+      'Complex TXO spending group required. Please consolidate balances or send in increments.',
+    );
+  }
+
+  private createSingleSpendingSolutionGroupIfPossible(
+    treeSortedBalances: TreeBalance[],
+    totalRequired: bigint,
+  ): SpendingSolutionGroup | undefined {
+    try {
+      const excludedUTXOIDs: string[] = [];
+      const { utxos, spendingTree, amount } = TransactionBatch.createSatisfyingUTXOGroup(
+        treeSortedBalances,
+        totalRequired,
+        excludedUTXOIDs,
+      );
+      if (amount < totalRequired) {
+        throw new Error('Could not find UTXOs to satisfy required amount.');
+      }
+
+      const spendingSolutionGroup: SpendingSolutionGroup = {
+        utxos,
+        spendingTree,
+        withdrawValue: this.withdrawTotal,
+        outputs: this.outputs,
+      };
+
+      return spendingSolutionGroup;
+    } catch (err) {
+      return undefined;
+    }
+  }
+
+  /**
+   * Finds group of UTXOs above required amount, excluding an already-used array of UTXO IDs.
+   */
+  private static createSatisfyingUTXOGroup(
+    treeSortedBalances: TreeBalance[],
+    amountRequired: bigint,
+    excludedUTXOIDs: string[],
+  ): { utxos: TXO[]; spendingTree: number; amount: bigint } {
+    let spendingTree: number | undefined;
+    let utxos: TXO[] | undefined;
+
+    // Find first tree with spending solutions.
+    treeSortedBalances.forEach((treeBalance, tree) => {
+      const solutions = findSolutions(treeBalance, amountRequired, excludedUTXOIDs);
+      if (!solutions) {
+        return;
+      }
+      spendingTree = tree;
+      utxos = solutions;
+    });
+
+    if (utxos == null || spendingTree == null) {
+      // Wallet has appropriate balance in aggregate, but no solutions remain.
+      // This means these UTXOs were already excluded, which can only occur in multi-send situations with multiple destination addresses.
+      throw new Error(
+        'You must consolidate balances before multi-sending. Send tokens to one destination address at a time to resolve.',
+      );
+    }
+
+    return {
+      utxos,
+      spendingTree,
+      amount: calculateTotalSpend(utxos),
+    };
+  }
+
+  /**
+   * Generate proofs and return serialized transactions
+   * @param prover - prover to use
+   * @param wallet - wallet to spend from
+   * @param encryptionKey - encryption key for wallet
+   * @returns serialized transaction
+   */
+  async generateSerializedTransactions(
+    prover: Prover,
+    wallet: Wallet,
+    encryptionKey: string,
+  ): Promise<SerializedTransaction[]> {
+    const proofPromises: Promise<SerializedTransaction>[] = [];
+
+    const spendingSolutionGroups = await this.generateValidSpendingSolutionGroups(wallet);
+    spendingSolutionGroups.forEach((spendingSolutionGroup) => {
+      const transaction = this.generateTransactionForSpendingSolutionGroup(spendingSolutionGroup);
+      proofPromises.push(transaction.prove(prover, wallet, encryptionKey));
+    });
+
+    return Promise.all(proofPromises);
+  }
+
+  /**
+   * Generate dummy proofs and return serialized transactions
+   * @param wallet - wallet to spend from
+   * @param encryptionKey - encryption key for wallet
+   * @returns serialized transaction
+   */
+  async generateDummySerializedTransactions(
+    wallet: Wallet,
+    encryptionKey: string,
+  ): Promise<SerializedTransaction[]> {
+    const proofPromises: Promise<SerializedTransaction>[] = [];
+
+    const spendingSolutionGroups = await this.generateValidSpendingSolutionGroups(wallet);
+    spendingSolutionGroups.forEach((spendingSolutionGroup) => {
+      const transaction = this.generateTransactionForSpendingSolutionGroup(spendingSolutionGroup);
+      proofPromises.push(transaction.dummyProve(wallet, encryptionKey));
+    });
+
+    return Promise.all(proofPromises);
+  }
+
+  generateTransactionForSpendingSolutionGroup(
+    spendingSolutionGroup: SpendingSolutionGroup,
+  ): Transaction {
+    const { spendingTree, utxos, outputs, withdrawValue } = spendingSolutionGroup;
+    const transaction = new Transaction(
+      this.tokenAddress,
+      this.tokenType,
+      this.chainID,
+      spendingTree,
+      utxos,
+    );
+    transaction.setOutputs(outputs);
+    if (withdrawValue > 0) {
+      transaction.withdraw(this.withdrawAddress, withdrawValue, this.overrideWithdrawAddress);
+    }
+    return transaction;
+  }
+}
+
+export { TransactionBatch };

--- a/src/transaction/transaction.ts
+++ b/src/transaction/transaction.ts
@@ -211,7 +211,7 @@ class Transaction {
       },
     );
     const boundParams: BoundParams = {
-      treeNumber: BigInt(this.spendingTree), // TODO: Is this correct tree?
+      treeNumber: BigInt(this.spendingTree),
       withdraw: this.withdrawFlag,
       adaptContract: this.adaptID.contract,
       adaptParams: this.adaptID.parameters,

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js';
 import crypto from 'crypto';
 import { hexToBytes } from 'ethereum-cryptography/utils';
-import { BytesData } from '../models/transaction-types';
+import { BytesData } from '../models/formatted-types';
 
 export enum ByteLength {
   UINT_8 = 1,

--- a/src/utils/ciphertext.ts
+++ b/src/utils/ciphertext.ts
@@ -1,4 +1,4 @@
-import { Ciphertext, EncryptedData } from '../models/transaction-types';
+import { Ciphertext, EncryptedData } from '../models/formatted-types';
 import { ByteLength, chunk, combine, formatToByteLength } from './bytes';
 
 export const ciphertextToEncryptedRandomData = (ciphertext: Ciphertext): EncryptedData => {

--- a/src/utils/ecies.ts
+++ b/src/utils/ecies.ts
@@ -1,4 +1,4 @@
-import { EncryptedData } from '../models/transaction-types';
+import { EncryptedData } from '../models/formatted-types';
 import { toUTF8String, combine, chunk, fromUTF8String } from './bytes';
 import { encryptedDataToCiphertext, ciphertextToEncryptedJSONData } from './ciphertext';
 import { aes } from './encryption';

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { arrayify, ByteLength, formatToByteLength, padToLength, random, trim } from './bytes';
-import { BytesData, Ciphertext } from '../models/transaction-types';
+import { BytesData, Ciphertext } from '../models/formatted-types';
 
 const aes = {
   gcm: {

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,10 +1,8 @@
 // @ts-ignore
 import { poseidon } from 'circomlibjs';
 import { utils as ethersutils } from 'ethers';
-import { BytesData } from '../models/transaction-types';
+import { BytesData } from '../models/formatted-types';
 import { arrayify } from './bytes';
-
-
 
 /**
  * Calculates sha256 hash of bytes
@@ -19,7 +17,6 @@ function sha256(preImage: BytesData): string {
   // Hash and return
   return ethersutils.sha256(preImageFormatted).slice(2);
 }
-
 
 /**
  * Calculates sha512 hmac

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -9,7 +9,7 @@ import { mnemonicToSeed } from '../keyderivation/bip39';
 import { Note } from '../note';
 import { MerkleTree } from '../merkletree';
 import { bech32, Node } from '../keyderivation';
-import { BytesData, Commitment, NoteSerialized } from '../models/transaction-types';
+import { BytesData, Commitment, NoteSerialized } from '../models/formatted-types';
 import {
   arrayify,
   ByteLength,
@@ -33,11 +33,12 @@ import {
   Balances,
   BalancesByTree,
   ScannedEventData,
-  TXO,
   WalletData,
   TreeBalance,
-  WalletNodes,
 } from './types';
+import { TXO } from '../models/txo-types';
+
+type WalletNodes = { spending: Node; viewing: Node };
 
 /**
  * constant defining the derivation path prefixes for spending and viewing keys

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -1,16 +1,7 @@
-import { Note } from '../note';
-import { Node } from '../keyderivation';
+import { TXO } from '../models/txo-types';
 
 export type WalletDetails = {
   treeScannedHeights: number[];
-};
-
-export type TXO = {
-  tree: number;
-  position: number;
-  txid: string;
-  spendtxid: string | false;
-  note: Note;
 };
 
 export type TreeBalance = {
@@ -38,5 +29,3 @@ export type AddressKeys = {
 };
 
 export type WalletData = { mnemonic: string; index: number };
-
-export type WalletNodes = { spending: Node; viewing: Node };

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -7,7 +7,7 @@ import { PublicInputs } from '../src/prover';
 import { ScannedEventData, Wallet } from '../src/wallet';
 import { AccumulatedEvents, QuickSync } from '../src';
 import { CommitmentEvent } from '../src/contract/erc20/events';
-import { Nullifier } from '../src/models/transaction-types';
+import { Nullifier } from '../src/models/formatted-types';
 
 export const DECIMALS_18 = BigInt(10) ** BigInt(18);
 const WALLET_PATH = "m/44'/60'/0'/0/0";

--- a/test/merkleTree/index.test.ts
+++ b/test/merkleTree/index.test.ts
@@ -9,7 +9,7 @@ import { Database } from '../../src/database';
 import { MERKLE_ZERO_VALUE, MerkleTree } from '../../src/merkletree';
 import type { TreePurpose } from '../../src/merkletree';
 import { ZERO_ADDRESS } from '../../src/utils/constants';
-import { TokenType } from '../../src/models/transaction-types';
+import { TokenType } from '../../src/models/formatted-types';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/test/note/erc20-deposit.test.ts
+++ b/test/note/erc20-deposit.test.ts
@@ -2,13 +2,13 @@
 import { randomBytes } from '@noble/hashes/utils';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { TokenType } from '../../src/models/transaction-types';
 import { ERC20Deposit } from '../../src/note';
 import { formatToByteLength, hexlify, hexToBigInt, random } from '../../src/utils/bytes';
 import { ZERO_ADDRESS } from '../../src/utils/constants';
 import { getRandomScalar } from '../../src/utils/keys-utils';
 import { poseidon } from '../../src/utils/hash';
 import { config } from '../config.test';
+import { TokenType } from '../../src/models/formatted-types';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;

--- a/test/utils/ciphertext.test.ts
+++ b/test/utils/ciphertext.test.ts
@@ -1,7 +1,6 @@
 /* globals describe it */
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BytesData } from '../../src/models/transaction-types';
 import { encryption } from '../../src/utils';
 import { random } from '../../src/utils/bytes';
 import {

--- a/test/utils/encryption.test.ts
+++ b/test/utils/encryption.test.ts
@@ -2,7 +2,6 @@
 /* globals describe it */
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { BytesData } from '../../src/models/transaction-types';
 import { bytes, encryption } from '../../src/utils';
 import { ByteLength, nToHex, random } from '../../src/utils/bytes';
 

--- a/test/wallet/index.test.ts
+++ b/test/wallet/index.test.ts
@@ -9,7 +9,6 @@ import memdown from 'memdown';
 import { Database } from '../../src/database';
 import { bech32 } from '../../src/keyderivation';
 import { MerkleTree } from '../../src/merkletree';
-import { Commitment, Nullifier } from '../../src/models/transaction-types';
 import { bytes, hash } from '../../src/utils';
 import { verifyED25519 } from '../../src/utils/keys-utils';
 import { Wallet } from '../../src/wallet';


### PR DESCRIPTION
We need TransactionBatch as a top-level constructor, which will find spending solution groups and create/prove Transactions for each group.

This is a precursor to enabling more complex transaction batches. The logic creates a single Transaction at the moment, and will throw on more complex (same as current logic).

More complex includes: 
- Using Balances split across multiple trees
- 3 to 7 UTXOs (nullifiers) required, or 9+ UTXOs
- 3+ UTXOs, and 3+ outputs
- 1 UTXO sent to 1 output (eg. if you pay Relayer in a different token)